### PR TITLE
Test enhancement about some PHPUnit stuffs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - '7.1'
   - '7.2'
   - '7.3'
+  - '7.4'
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
@@ -12,7 +13,7 @@ before_script:
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-source
 
-script: 
+script:
   - mkdir -p build/logs
   - php vendor/bin/phpstan analyze --level max src
   - vendor/bin/phpunit --coverage-text --coverage-clover build/logs/clover.xml

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "phpunit/phpunit": "7.*|8.*",
         "symfony/var-dumper": "^4.2",
         "phpstan/phpstan": "^0.11.6",
-        "carbondate/carbon": "^1.33",
+        "nesbot/carbon": "^2.37",
         "phpbench/phpbench": "^0.16.9"
     },
     "autoload": {
@@ -41,8 +41,5 @@
         "psr-4": {
             "PHPExperts\\DataTypeValidator\\Tests\\": "tests/"
         }
-    },
-    "config": {
-        "classmap-authoritative": true
     }
 }

--- a/tests/DataTypeValidatorAssertTest.php
+++ b/tests/DataTypeValidatorAssertTest.php
@@ -29,7 +29,7 @@ class DataTypeValidatorAssertTest extends TestCase
     /** @var DataTypeValidator */
     private $fuzzy;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->strict = new DataTypeValidator(new IsAStrictDataType());
         $this->fuzzy = new DataTypeValidator(new IsAFuzzyDataType());

--- a/tests/DataTypeValidatorTest.php
+++ b/tests/DataTypeValidatorTest.php
@@ -30,7 +30,7 @@ class DataTypeValidatorTest extends TestCase
     /** @var DataTypeValidator */
     private $fuzzy;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->strict = new DataTypeValidator(new IsAStrictDataType());
         $this->fuzzy = new DataTypeValidator(new IsAFuzzyDataType());

--- a/tests/DataTypeValidatorTypesTest.php
+++ b/tests/DataTypeValidatorTypesTest.php
@@ -28,7 +28,7 @@ class DataTypeValidatorTypesTest extends TestCase
     /** @var DataTypeValidator */
     private $fuzzy;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->strict = new DataTypeValidator(new IsAStrictDataType());
         $this->fuzzy = new DataTypeValidator(new IsAFuzzyDataType());
@@ -177,21 +177,21 @@ class DataTypeValidatorTypesTest extends TestCase
 
     public function testWillValidateObjectsByTheirShortName()
     {
-        $this->assertTrue($this->strict->isFuzzyObject($this->strict, 'DataTypeValidator'));
-        $this->assertTrue($this->fuzzy->isFuzzyObject($this->fuzzy, 'DataTypeValidator'));
-        $this->assertFalse($this->strict->isFuzzyObject($this->strict, 'doesntexist'));
-        $this->assertFalse($this->fuzzy->isFuzzyObject($this->fuzzy, 'doesntexist'));
+        self::assertTrue($this->strict->isFuzzyObject($this->strict, 'DataTypeValidator'));
+        self::assertTrue($this->fuzzy->isFuzzyObject($this->fuzzy, 'DataTypeValidator'));
+        self::assertFalse($this->strict->isFuzzyObject($this->strict, 'doesntexist'));
+        self::assertFalse($this->fuzzy->isFuzzyObject($this->fuzzy, 'doesntexist'));
     }
 
     public function testWillValidateObjectsByTheirFullName()
     {
-        $this->assertTrue($this->strict->isSpecificObject($this->strict, DataTypeValidator::class));
-        $this->assertTrue($this->fuzzy->isSpecificObject($this->fuzzy, DataTypeValidator::class));
+        self::assertTrue($this->strict->isSpecificObject($this->strict, DataTypeValidator::class));
+        self::assertTrue($this->fuzzy->isSpecificObject($this->fuzzy, DataTypeValidator::class));
 
-        $this->assertFalse($this->strict->isSpecificObject($this->strict, 'DataTypeValidator'));
-        $this->assertFalse($this->fuzzy->isSpecificObject($this->fuzzy, 'DataTypeValidator'));
-        $this->assertFalse($this->strict->isSpecificObject($this->strict, 'doesntexist'));
-        $this->assertFalse($this->fuzzy->isSpecificObject($this->fuzzy, 'doesntexist'));
+        self::assertFalse($this->strict->isSpecificObject($this->strict, 'DataTypeValidator'));
+        self::assertFalse($this->fuzzy->isSpecificObject($this->fuzzy, 'DataTypeValidator'));
+        self::assertFalse($this->strict->isSpecificObject($this->strict, 'doesntexist'));
+        self::assertFalse($this->fuzzy->isSpecificObject($this->fuzzy, 'doesntexist'));
     }
 
     public function testCanValidateBoolsLoosely()

--- a/tests/IsAFuzzyDataTypeTest.php
+++ b/tests/IsAFuzzyDataTypeTest.php
@@ -23,7 +23,7 @@ class IsAFuzzyDataTypeTest extends TestCase
     /** @var IsAFuzzyDataType */
     private $isA;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->isA = new IsAFuzzyDataType();
 

--- a/tests/IsAStrictDataTypeTest.php
+++ b/tests/IsAStrictDataTypeTest.php
@@ -23,7 +23,7 @@ class IsAStrictDataTypeTest extends TestCase
     /** @var IsAStrictDataType */
     private $isA;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->isA = new IsAStrictDataType();
 


### PR DESCRIPTION
# Changed log

- Add `php-7.4` version test during Travis CI build.
- The `carbondate/carbon` package is abandoned/deprecated. Using the `nesbot/carbon` package instead.
- To be consistency, using the `self` approach to make PHPUnit assertion call.
- Using the `$this` approach to make `expectException` method call.
- To avoid deprecated class loading issue, it should remove `classmap-authoritative` config inside `composer.json` file.
- According to the [PHPUnit fixtures reference](https://phpunit.readthedocs.io/en/8.5/assertions.html#assertequals), it should be nice to use `protected function setUp(): void` method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phpexpertsinc/datatypevalidator/10)
<!-- Reviewable:end -->
