### PR TITLE
Version 2.0.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 PHP Experts, Inc.
+Copyright © 2019-2025 PHP Experts, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -162,6 +162,30 @@ PHPExperts\DataTypeValidator\IsAStrictDataType
  ✔ Will match specific classes  
  ✔ Will work with an array of something  
 
+Extended assertIsAType Tests  
+✔ has extended tests for asserting it is a strict string  
+✔ has extended tests for asserting it is a strict int  
+✔ has extended tests for asserting it is a strict bool  
+✔ has extended tests for asserting it is a strict array  
+✔ has extended tests for asserting it is a strict specific object  
+✔ has extended tests for asserting it is a fuzzy string  
+✔ has extended tests for asserting it is a fuzzy int  
+✔ has extended tests for asserting it is a fuzzy bool  
+✔ has extended tests for asserting it is a fuzzy array  
+✔ has extended tests for asserting it is a fuzzy object  
+✔ has extended tests for asserting it is a fuzzy specific object  
+✔ has extended tests for asserting it is not a strict string  
+✔ has extended tests for asserting it is not a strict int  
+✔ has extended tests for asserting it is not a strict bool  
+✔ has extended tests for asserting it is not a strict array  
+✔ has extended tests for asserting it is not a strict specific object  
+✔ has extended tests for asserting it is not a fuzzy string  
+✔ has extended tests for asserting it is not a fuzzy int  
+✔ has extended tests for asserting it is not a fuzzy bool  
+✔ has extended tests for asserting it is not a fuzzy array  
+✔ has extended tests for asserting it is not a fuzzy object  
+✔ has extended tests for asserting it is not a fuzzy specific object  
+
 ## Testing
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "7.*|8.*",
+        "phpunit/phpunit": "9.*",
         "symfony/var-dumper": "*",
         "phpstan/phpstan": "*",
         "nesbot/carbon": "^2.37",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": ">=8.0",
         "ext-json": "*"
     },
     "require-dev": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,25 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="./vendor/autoload.php"
          colors="true"
+         testdox="true"
+         stopOnError="true"
+         stopOnFailure="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
-         testdox="true"
-         stopOnError="true"
-         stopOnFailure="true">
-    <testsuites>
-        <testsuite name="main">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-
-    <logging>
-        <log type="coverage-html" target="./coverage" lowUpperBound="35" highLowerBound="85"/>
-    </logging>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <report>
+      <html outputDirectory="./coverage" lowUpperBound="35" highLowerBound="85"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="main">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/src/DataTypeValidator.php
+++ b/src/DataTypeValidator.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of DataTypeValidator, a PHP Experts, Inc., Project.
  *
- * Copyright © 2019 PHP Experts, Inc.
+ * Copyright © 2019-2025 PHP Experts, Inc.
  * Author: Theodore R. Smith <theodore@phpexperts.pro>
  *  GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
  *  https://www.phpexperts.pro/

--- a/src/DataTypeValidator.php
+++ b/src/DataTypeValidator.php
@@ -27,116 +27,116 @@ final class DataTypeValidator implements IsA
         return $this->isA::class;
     }
 
-    public function isBool($value): bool
+    public function isBool(mixed $value): bool
     {
         return $this->isA->isBool($value);
     }
 
-    public function isInt($value): bool
+    public function isInt(mixed $value): bool
     {
         return $this->isA->isInt($value);
     }
 
-    public function isFloat($value): bool
+    public function isFloat(mixed $value): bool
     {
         return $this->isA->isFloat($value);
     }
 
-    public function isString($value): bool
+    public function isString(mixed $value): bool
     {
         return $this->isA->isString($value);
     }
 
-    public function isArray($value): bool
+    public function isArray(mixed $value): bool
     {
         return $this->isA->isArray($value);
     }
 
-    public function isArrayOfSomething($values, string $dataType): bool
+    public function isArrayOfSomething(mixed $values, string $dataType): bool
     {
         return $this->isA->isArrayOfSomething($values, $dataType);
     }
 
-    public function isObject($value): bool
+    public function isObject(mixed $value): bool
     {
         return $this->isA->isObject($value);
     }
 
-    public function isCallable($value): bool
+    public function isCallable(mixed $value): bool
     {
         return $this->isA->isCallable($value);
     }
 
-    public function isResource($value): bool
+    public function isResource(mixed $value): bool
     {
         return $this->isA->isResource($value);
     }
 
-    public function isFuzzyObject($value, string $shortName): bool
+    public function isFuzzyObject(mixed $value, string $shortName): bool
     {
         return $this->isA->isFuzzyObject($value, $shortName);
     }
 
-    public function isSpecificObject($value, string $fullName): bool
+    public function isSpecificObject(mixed $value, string $fullName): bool
     {
         return $this->isA->isSpecificObject($value, $fullName);
     }
 
     /** @throws InvalidDataTypeException */
-    public function assertIsBool($value)
+    public function assertIsBool(mixed $value): void
     {
         $this->assertIsType($value, 'bool');
     }
 
     /** @throws InvalidDataTypeException */
-    public function assertIsInt($value)
+    public function assertIsInt(mixed $value): void
     {
         $this->assertIsType($value, 'int');
     }
 
     /** @throws InvalidDataTypeException */
-    public function assertIsFloat($value)
+    public function assertIsFloat(mixed $value): void
     {
         $this->assertIsType($value, 'float');
     }
 
     /** @throws InvalidDataTypeException */
-    public function assertIsString($value)
+    public function assertIsString(mixed $value): void
     {
         $this->assertIsType($value, 'string');
     }
 
     /** @throws InvalidDataTypeException */
-    public function assertIsArray($value)
+    public function assertIsArray(mixed $value): void
     {
         $this->assertIsType($value, 'array');
     }
 
     /** @throws InvalidDataTypeException */
-    public function assertIsObject($value)
+    public function assertIsObject(mixed $value): void
     {
         $this->assertIsType($value, 'object');
     }
 
     /** @throws InvalidDataTypeException */
-    public function assertIsCallable($value)
+    public function assertIsCallable(mixed $value): void
     {
         $this->assertIsType($value, 'callable');
     }
 
     /** @throws InvalidDataTypeException */
-    public function assertIsResource($value)
+    public function assertIsResource(mixed $value): void
     {
         $this->assertIsType($value, 'resource');
     }
 
     /** @throws InvalidDataTypeException */
-    public function assertIsSpecificObject($value, string $className)
+    public function assertIsSpecificObject(mixed $value, string $className): void
     {
         $this->assertIsType($value, $className);
     }
 
-    public function assertIsArrayOfSomething($values, string $dataType)
+    public function assertIsArrayOfSomething(mixed $values, string $dataType): void
     {
         $this->assertIsArray($values);
 
@@ -149,7 +149,7 @@ final class DataTypeValidator implements IsA
     }
 
     /** @throws InvalidDataTypeException */
-    public function assertIsType($value, $dataType): void
+    public function assertIsType(mixed $value, string $dataType): void
     {
         // We can just let PHP deal with user error when it comes to undefined method names :-/
         $isA = "is{$dataType}";
@@ -173,10 +173,10 @@ final class DataTypeValidator implements IsA
     /**
      * Validates an array of values for the proper types; Laravel-esque.
      *
-     * @param array $values
-     * @param array $rules
-     * @return bool true if completely valid.
-     * @throws InvalidDataTypeException if one or more values are not the correct data type.
+     * @param array<string, mixed> $values
+     * @param array<string, string> $rules
+     * @return bool
+     * @throws InvalidDataTypeException
      */
     public function validate(array $values, array $rules): bool
     {
@@ -193,7 +193,6 @@ final class DataTypeValidator implements IsA
                 } catch (InvalidDataTypeException $e) {
                     $reasons[$key] = "$key is not a valid array of $expectedType: " . $e->getMessage();
                 }
-
                 continue;
             }
 
@@ -207,7 +206,7 @@ final class DataTypeValidator implements IsA
 
         if (!empty($reasons)) {
             $count = count($reasons);
-            $s = $count > 1 ? 's': '';
+            $s = $count > 1 ? 's' : '';
             $wasWere = $count > 1 ? 'were' : 'was';
             throw new InvalidDataTypeException("There $wasWere $count validation error{$s}.", $reasons);
         }
@@ -215,7 +214,7 @@ final class DataTypeValidator implements IsA
         return true;
     }
 
-    private function validateValue($value, string $expectedType)
+    private function validateValue(mixed $value, string $expectedType): void
     {
         // Allow nullable types.
         $nullableType = $this->extractNullableProperty($expectedType);
@@ -230,7 +229,6 @@ final class DataTypeValidator implements IsA
         // Traditional values.
         if (in_array($expectedType, IsA::KNOWN_TYPES)) {
             $this->assertIsType($value, $expectedType);
-
             return;
         }
 
@@ -238,7 +236,7 @@ final class DataTypeValidator implements IsA
         $this->assertIsSpecificObject($value, $expectedType);
     }
 
-    private function validateArraysOfSomething($values, string $expectedType)
+    private function validateArraysOfSomething(mixed $values, string $expectedType): void
     {
         // Allow nullable types.
         $nullableType = $this->extractNullableProperty($expectedType);

--- a/src/InvalidDataTypeException.php
+++ b/src/InvalidDataTypeException.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of DataTypeValidator, a PHP Experts, Inc., Project.
  *
- * Copyright © 2019 PHP Experts, Inc.
+ * Copyright © 2019-2025 PHP Experts, Inc.
  * Author: Theodore R. Smith <theodore@phpexperts.pro>
  *  GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
  *  https://www.phpexperts.pro/

--- a/src/InvalidDataTypeException.php
+++ b/src/InvalidDataTypeException.php
@@ -20,13 +20,19 @@ use Throwable;
 class InvalidDataTypeException extends InvalidArgumentException
 {
     /**
-     * @param mixed[] $reasons
+     * @param string $message
+     * @param array<mixed> $reasons
+     * @param int $code
+     * @param Throwable|null $previous
      */
-    public function __construct($message, protected $reasons = [], $code = 0, Throwable $previous = null)
+    public function __construct(string $message, protected array $reasons = [], int $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }
 
+    /**
+     * @return array<mixed>
+     */
     public function getReasons(): array
     {
         return $this->reasons;

--- a/src/InvalidDataTypeException.php
+++ b/src/InvalidDataTypeException.php
@@ -19,13 +19,11 @@ use Throwable;
 
 class InvalidDataTypeException extends InvalidArgumentException
 {
-    /** @var array */
-    protected $reasons;
-
-    public function __construct($message, $reasons = [], $code = 0, Throwable $previous = null)
+    /**
+     * @param mixed[] $reasons
+     */
+    public function __construct($message, protected $reasons = [], $code = 0, Throwable $previous = null)
     {
-        $this->reasons = $reasons;
-
         parent::__construct($message, $code, $previous);
     }
 

--- a/src/IsA.php
+++ b/src/IsA.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of DataTypeValidator, a PHP Experts, Inc., Project.
  *
- * Copyright © 2019 PHP Experts, Inc.
+ * Copyright © 2019-2025 PHP Experts, Inc.
  * Author: Theodore R. Smith <theodore@phpexperts.pro>
  *  GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
  *  https://www.phpexperts.pro/

--- a/src/IsA.php
+++ b/src/IsA.php
@@ -18,15 +18,15 @@ interface IsA
 {
     public const KNOWN_TYPES = ['string', 'int', 'array', 'bool', 'float', 'double', 'object', 'callable', 'resource'];
 
-    public function isBool($value): bool;
-    public function isInt($value): bool;
-    public function isFloat($value): bool;
-    public function isString($value): bool;
-    public function isArray($value): bool;
-    public function isArrayOfSomething($values, string $dataType): bool;
-    public function isObject($value): bool;
-    public function isCallable($value): bool;
-    public function isResource($value): bool;
-    public function isFuzzyObject($value, string $shortName): bool;
-    public function isSpecificObject($value, string $fullName): bool;
+    public function isBool(mixed $value): bool;
+    public function isInt(mixed $value): bool;
+    public function isFloat(mixed $value): bool;
+    public function isString(mixed $value): bool;
+    public function isArray(mixed $value): bool;
+    public function isArrayOfSomething(mixed $values, string $dataType): bool;
+    public function isObject(mixed $value): bool;
+    public function isCallable(mixed $value): bool;
+    public function isResource(mixed $value): bool;
+    public function isFuzzyObject(mixed $value, string $shortName): bool;
+    public function isSpecificObject(mixed $value, string $fullName): bool;
 }

--- a/src/IsADataType.php
+++ b/src/IsADataType.php
@@ -21,7 +21,7 @@ abstract class IsADataType implements IsA
         $isA = "is{$dataType}";
 
         if (!in_array($dataType, IsA::KNOWN_TYPES)) {
-            $isA = strpos($dataType, '\\') !== false ? 'isSpecificObject' : 'isFuzzyObject';
+            $isA = str_contains($dataType, '\\') ? 'isSpecificObject' : 'isFuzzyObject';
         }
 
         // Thank you, PHP devs, for letting me throw on extra function parameters without even throwing a warning. /no-sarc

--- a/src/IsADataType.php
+++ b/src/IsADataType.php
@@ -18,7 +18,7 @@ use ReflectionClass;
 
 abstract class IsADataType implements IsA
 {
-    public function isType($value, $dataType): bool
+    public function isType(mixed $value, string $dataType): bool
     {
         $isA = "is{$dataType}";
 
@@ -30,7 +30,7 @@ abstract class IsADataType implements IsA
         return $this->$isA($value, $dataType);
     }
 
-    public function isArrayOfSomething($values, string $dataType): bool
+    public function isArrayOfSomething(mixed $values, string $dataType): bool
     {
         if (!$this->isArray($values)) {
             return false;
@@ -44,22 +44,23 @@ abstract class IsADataType implements IsA
 
         return true;
     }
-    public function isObject($value): bool
+
+    public function isObject(mixed $value): bool
     {
         return is_object($value);
     }
 
-    public function isCallable($value): bool
+    public function isCallable(mixed $value): bool
     {
         return is_callable($value);
     }
 
-    public function isResource($value): bool
+    public function isResource(mixed $value): bool
     {
         return is_resource($value);
     }
 
-    public function isFuzzyObject($value, string $shortName): bool
+    public function isFuzzyObject(mixed $value, string $shortName): bool
     {
         if (!is_object($value)) {
             return false;
@@ -70,7 +71,7 @@ abstract class IsADataType implements IsA
         return strtolower($shortName) === strtolower($actualShortName);
     }
 
-    public function isSpecificObject($value, string $fullName): bool
+    public function isSpecificObject(mixed $value, string $fullName): bool
     {
         if (!is_object($value)) {
             return false;

--- a/src/IsADataType.php
+++ b/src/IsADataType.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of DataTypeValidator, a PHP Experts, Inc., Project.
  *
- * Copyright © 2019 PHP Experts, Inc.
+ * Copyright © 2019-2025 PHP Experts, Inc.
  * Author: Theodore R. Smith <theodore@phpexperts.pro>
  *  GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
  *  https://www.phpexperts.pro/
@@ -13,6 +13,8 @@
  */
 
 namespace PHPExperts\DataTypeValidator;
+
+use ReflectionClass;
 
 abstract class IsADataType implements IsA
 {
@@ -26,5 +28,54 @@ abstract class IsADataType implements IsA
 
         // Thank you, PHP devs, for letting me throw on extra function parameters without even throwing a warning. /no-sarc
         return $this->$isA($value, $dataType);
+    }
+
+    public function isArrayOfSomething($values, string $dataType): bool
+    {
+        if (!$this->isArray($values)) {
+            return false;
+        }
+
+        foreach ($values as $value) {
+            if (!$this->isType($value, $dataType)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+    public function isObject($value): bool
+    {
+        return is_object($value);
+    }
+
+    public function isCallable($value): bool
+    {
+        return is_callable($value);
+    }
+
+    public function isResource($value): bool
+    {
+        return is_resource($value);
+    }
+
+    public function isFuzzyObject($value, string $shortName): bool
+    {
+        if (!is_object($value)) {
+            return false;
+        }
+
+        $actualShortName = (new ReflectionClass($value))->getShortName();
+
+        return strtolower($shortName) === strtolower($actualShortName);
+    }
+
+    public function isSpecificObject($value, string $fullName): bool
+    {
+        if (!is_object($value)) {
+            return false;
+        }
+
+        return $fullName === $value::class;
     }
 }

--- a/src/IsAFuzzyDataType.php
+++ b/src/IsAFuzzyDataType.php
@@ -18,9 +18,19 @@ class IsAFuzzyDataType  extends IsADataType implements IsA
 {
     public function isBool(mixed $value): bool
     {
-        return is_bool($value) || $value === null || !in_array(gettype($value), ['object', 'resource', 'unknown type']);
-    }
+        $isSpecialType = in_array(gettype($value), ['object', 'resource', 'unknown type']);
+        if ($isSpecialType === true) {
+            return false;
+        }
 
+        $isBool = is_bool($value);
+        $isNull = $value === null;
+        $isArray = is_array($value);
+        $isLooseValue = in_array($value, [true, false, 0, 1, "0", "1"], true);
+        $isNumericAndGreaterThan0 = is_numeric($value) && $value >= 0.0;
+
+        return $isBool || $isNull || $isArray || $isLooseValue || $isNumericAndGreaterThan0;
+    }
     public function isInt(mixed $value): bool
     {
         if (!is_numeric($value)) {

--- a/src/IsAFuzzyDataType.php
+++ b/src/IsAFuzzyDataType.php
@@ -16,12 +16,12 @@ namespace PHPExperts\DataTypeValidator;
 
 class IsAFuzzyDataType  extends IsADataType implements IsA
 {
-    public function isBool($value): bool
+    public function isBool(mixed $value): bool
     {
         return is_bool($value) || $value === null || !in_array(gettype($value), ['object', 'resource', 'unknown type']);
     }
 
-    public function isInt($value): bool
+    public function isInt(mixed $value): bool
     {
         if (!is_numeric($value)) {
             return false;
@@ -30,18 +30,18 @@ class IsAFuzzyDataType  extends IsADataType implements IsA
         return is_int($value) || filter_var($value, FILTER_VALIDATE_INT) !== false || (float) (int) $value === $value;
     }
 
-    public function isFloat($value): bool
+    public function isFloat(mixed $value): bool
     {
         return is_float($value) || filter_var($value, FILTER_VALIDATE_FLOAT) !== false;
     }
 
-    public function isString($value): bool
+    public function isString(mixed $value): bool
     {
         return is_string($value);
     }
 
-    public function isArray($value): bool
+    public function isArray(mixed $value): bool
     {
-        return is_array($value) || is_object($value) && $value instanceof \ArrayAccess;
+        return is_array($value) || $value instanceof \ArrayAccess;
     }
 }

--- a/src/IsAFuzzyDataType.php
+++ b/src/IsAFuzzyDataType.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of DataTypeValidator, a PHP Experts, Inc., Project.
  *
- * Copyright © 2019 PHP Experts, Inc.
+ * Copyright © 2019-2025 PHP Experts, Inc.
  * Author: Theodore R. Smith <theodore@phpexperts.pro>
  *  GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
  *  https://www.phpexperts.pro/
@@ -14,7 +14,7 @@
 
 namespace PHPExperts\DataTypeValidator;
 
-class IsAFuzzyDataType extends IsAStrictDataType
+class IsAFuzzyDataType  extends IsADataType implements IsA
 {
     public function isBool($value): bool
     {

--- a/src/IsAStrictDataType.php
+++ b/src/IsAStrictDataType.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of DataTypeValidator, a PHP Experts, Inc., Project.
  *
- * Copyright © 2019 PHP Experts, Inc.
+ * Copyright © 2019-2025 PHP Experts, Inc.
  * Author: Theodore R. Smith <theodore@phpexperts.pro>
  *  GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
  *  https://www.phpexperts.pro/
@@ -14,9 +14,7 @@
 
 namespace PHPExperts\DataTypeValidator;
 
-use ReflectionClass;
-
-class IsAStrictDataType extends IsADataType
+class IsAStrictDataType extends IsADataType implements IsA
 {
     public function isBool($value): bool
     {
@@ -41,55 +39,5 @@ class IsAStrictDataType extends IsADataType
     public function isArray($value): bool
     {
         return is_array($value);
-    }
-
-    public function isArrayOfSomething($values, string $dataType): bool
-    {
-        if (!$this->isArray($values)) {
-            return false;
-        }
-
-        foreach ($values as $value) {
-            if (!$this->isType($value, $dataType)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    public function isObject($value): bool
-    {
-        return is_object($value);
-    }
-
-    public function isCallable($value): bool
-    {
-        return is_callable($value);
-    }
-
-    public function isResource($value): bool
-    {
-        return is_resource($value);
-    }
-
-    public function isFuzzyObject($value, string $shortName): bool
-    {
-        if (!is_object($value)) {
-            return false;
-        }
-
-        $actualShortName = (new ReflectionClass($value))->getShortName();
-
-        return strtolower($shortName) === strtolower($actualShortName);
-    }
-
-    public function isSpecificObject($value, string $fullName): bool
-    {
-        if (!is_object($value)) {
-            return false;
-        }
-
-        return $fullName === $value::class;
     }
 }

--- a/src/IsAStrictDataType.php
+++ b/src/IsAStrictDataType.php
@@ -90,6 +90,6 @@ class IsAStrictDataType extends IsADataType
             return false;
         }
 
-        return $fullName === get_class($value);
+        return $fullName === $value::class;
     }
 }

--- a/src/IsAStrictDataType.php
+++ b/src/IsAStrictDataType.php
@@ -16,27 +16,27 @@ namespace PHPExperts\DataTypeValidator;
 
 class IsAStrictDataType extends IsADataType implements IsA
 {
-    public function isBool($value): bool
+    public function isBool(mixed $value): bool
     {
         return is_bool($value);
     }
 
-    public function isInt($value): bool
+    public function isInt(mixed $value): bool
     {
         return is_int($value);
     }
 
-    public function isFloat($value): bool
+    public function isFloat(mixed $value): bool
     {
         return is_float($value);
     }
 
-    public function isString($value): bool
+    public function isString(mixed $value): bool
     {
         return is_string($value);
     }
 
-    public function isArray($value): bool
+    public function isArray(mixed $value): bool
     {
         return is_array($value);
     }

--- a/tests/AssertIsATypeTest.php
+++ b/tests/AssertIsATypeTest.php
@@ -37,8 +37,7 @@ class AssertIsATypeTest extends TestCase
         $this->fuzzy = new DataTypeValidator(new IsAFuzzyDataType());
     }
 
-    private function assertPassValues(DataTypeValidator $validator, array $values, string $type):
-    void
+    private function assertPassValues(DataTypeValidator $validator, array $values, string $type): void
     {
         foreach ($values as $value) {
             try {
@@ -50,8 +49,7 @@ class AssertIsATypeTest extends TestCase
         $this->assertTrue(true);
     }
 
-    private function assertFailValues(DataTypeValidator $validator, array $values, string $type):
-    void
+    private function assertFailValues(DataTypeValidator $validator, array $values, string $type): void
     {
         foreach ($values as $value) {
             try {

--- a/tests/AssertIsATypeTest.php
+++ b/tests/AssertIsATypeTest.php
@@ -37,7 +37,8 @@ class AssertIsATypeTest extends TestCase
         $this->fuzzy = new DataTypeValidator(new IsAFuzzyDataType());
     }
 
-    private function assertPassValues($validator, array $values, string $type): void
+    private function assertPassValues(DataTypeValidator $validator, array $values, string $type):
+    void
     {
         foreach ($values as $value) {
             try {
@@ -49,7 +50,8 @@ class AssertIsATypeTest extends TestCase
         $this->assertTrue(true);
     }
 
-    private function assertFailValues($validator, array $values, string $type): void
+    private function assertFailValues(DataTypeValidator $validator, array $values, string $type):
+    void
     {
         foreach ($values as $value) {
             try {

--- a/tests/AssertIsATypeTest.php
+++ b/tests/AssertIsATypeTest.php
@@ -1,0 +1,227 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of DataTypeValidator, a PHP Experts, Inc., Project.
+ *
+ * Copyright © 2025 PHP Experts, Inc.
+ * Author: Theodore R. Smith <theodore@phpexperts.pro>
+ *  GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
+ *  https://www.phpexperts.pro/
+ *  https://github.com/phpexpertsinc/DataTypeValidator
+ *
+ * This file is licensed under the MIT License.
+ */
+
+namespace PHPExperts\DataTypeValidator\Tests;
+
+use PHPExperts\DataTypeValidator\DataTypeValidator;
+use PHPExperts\DataTypeValidator\InvalidDataTypeException;
+use PHPExperts\DataTypeValidator\IsAFuzzyDataType;
+use PHPExperts\DataTypeValidator\IsAStrictDataType;
+use PHPUnit\Framework\TestCase;
+
+// Dummy classes for object validation tests.
+class TestDummy {}
+class AnotherDummy {}
+
+/** @testdox Extended assertIsAType Tests */
+class AssertIsATypeTest extends TestCase
+{
+    private $strict;
+    private $fuzzy;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->strict = new DataTypeValidator(new IsAStrictDataType());
+        $this->fuzzy = new DataTypeValidator(new IsAFuzzyDataType());
+    }
+
+    private function assertPassValues($validator, array $values, string $type): void
+    {
+        foreach ($values as $value) {
+            try {
+                $validator->assertIsType($value, $type);
+            } catch (InvalidDataTypeException $e) {
+                $this->fail("Expected " . var_export($value, true) . " to be accepted as $type: " . $e->getMessage());
+            }
+        }
+        $this->assertTrue(true);
+    }
+
+    private function assertFailValues($validator, array $values, string $type): void
+    {
+        foreach ($values as $value) {
+            try {
+                $validator->assertIsType($value, $type);
+                $this->fail("Expected " . var_export($value, true) . " to be rejected as $type.");
+            } catch (InvalidDataTypeException $e) {
+                $this->assertTrue(true);
+            }
+
+            if (is_resource($value)) {
+                fclose($value);
+            }
+        }
+    }
+
+    // === Strict Tests ===
+
+    /** @testdox has extended tests for asserting it is a strict string */
+    public function testAssertIsStrictString(): void
+    {
+        $values = ["hello", "", "0", "123", "true", "false", " "];
+        $this->assertPassValues($this->strict, $values, "string");
+    }
+
+    /** @testdox has extended tests for asserting it is a strict int */
+    public function testAssertIsStrictInt(): void
+    {
+        $values = [123, -456, 0];
+        $this->assertPassValues($this->strict, $values, "int");
+    }
+
+    /** @testdox has extended tests for asserting it is a strict bool */
+    public function testAssertIsStrictBool(): void
+    {
+        $values = [true, false];
+        $this->assertPassValues($this->strict, $values, "bool");
+    }
+
+    /** @testdox has extended tests for asserting it is a strict array */
+    public function testAssertIsStrictArray(): void
+    {
+        $values = [[], [1, 2, 3], ["a", "b"], [1 => 'a', 2 => 'b']];
+        $this->assertPassValues($this->strict, $values, "array");
+    }
+
+    /** @testdox has extended tests for asserting it is a strict specific object */
+    public function testAssertIsStrictSpecificObject(): void
+    {
+        $values = [new TestDummy()];
+        $this->assertPassValues($this->strict, $values, TestDummy::class);
+    }
+
+    // === Fuzzy Tests ===
+
+    /** @testdox has extended tests for asserting it is a fuzzy string */
+    public function testAssertIsFuzzyString(): void
+    {
+        $values = ["hello", "", "0", "123", "true", "false", " "];
+        $this->assertPassValues($this->fuzzy, $values, "string");
+    }
+
+    /** @testdox has extended tests for asserting it is a fuzzy int */
+    public function testAssertIsFuzzyInt(): void
+    {
+        $values = [123, -456, 0, "123", "-456", "0"];
+        $this->assertPassValues($this->fuzzy, $values, "int");
+    }
+
+    /** @testdox has extended tests for asserting it is a fuzzy bool */
+    public function testAssertIsFuzzyBool(): void
+    {
+        $values = [true, false, null, 0, 1, "0", "1", 0.1, 123];
+        $this->assertPassValues($this->fuzzy, $values, "bool");
+    }
+
+    /** @testdox has extended tests for asserting it is a fuzzy array */
+    public function testAssertIsFuzzyArray(): void
+    {
+        $values = [[], [1, 2, 3], ["a", "b"], [1 => 'a', 2 => 'b']];
+        $this->assertPassValues($this->fuzzy, $values, "array");
+    }
+
+    /** @testdox has extended tests for asserting it is a fuzzy object */
+    public function testAssertIsFuzzyObject(): void
+    {
+        $values = [new TestDummy()];
+        $this->assertPassValues($this->fuzzy, $values, 'TestDummy');
+    }
+
+    /** @testdox has extended tests for asserting it is a fuzzy specific object */
+    public function testAssertIsFuzzySpecificObject(): void
+    {
+        $values = [new TestDummy()];
+        $this->assertPassValues($this->fuzzy, $values, TestDummy::class);
+    }
+
+    // === NOT Strict Tests ===
+
+    /** @testdox has extended tests for asserting it is not a strict string */
+    public function testAssertIsNotStrictString(): void
+    {
+        $values = [123, 1.23, true, false, null, [], [1, 2, 3], new \stdClass(), fopen('php://memory', 'r')];
+        $this->assertFailValues($this->strict, $values, "string");
+    }
+
+    /** @testdox has extended tests for asserting it is not a strict int */
+    public function testAssertIsNotStrictInt(): void
+    {
+        $values = ["123", "abc", 1.23, true, false, null, [], [1, 2, 3], new \stdClass(), fopen('php://memory', 'r')];
+        $this->assertFailValues($this->strict, $values, "int");
+    }
+
+    /** @testdox has extended tests for asserting it is not a strict bool */
+    public function testAssertIsNotStrictBool(): void
+    {
+        $values = ["true", "false", 0, 1, null, [], [1, 2, 3], new \stdClass(), fopen('php://memory', 'r')];
+        $this->assertFailValues($this->strict, $values, "bool");
+    }
+
+    /** @testdox has extended tests for asserting it is not a strict array */
+    public function testAssertIsNotStrictArray(): void
+    {
+        $values = ["not an array", 123, 1.23, true, false, null, new \stdClass(), fopen('php://memory', 'r')];
+        $this->assertFailValues($this->strict, $values, "array");
+    }
+
+    /** @testdox has extended tests for asserting it is not a strict specific object */
+    public function testAssertIsNotStrictSpecificObject(): void
+    {
+        $values = [new AnotherDummy(), "not an object", 123, 1.23, null, [], [1, 2, 3], new \stdClass(), fopen('php://memory', 'r')];
+        $this->assertFailValues($this->strict, $values, TestDummy::class);
+    }
+
+    /** @testdox has extended tests for asserting it is not a fuzzy string */
+    public function testAssertIsNotFuzzyString(): void
+    {
+        $values = [123, 1.23, true, false, null, [], [1, 2, 3], new \stdClass(), fopen('php://memory', 'r')];
+        $this->assertFailValues($this->fuzzy, $values, "string");
+    }
+
+    /** @testdox has extended tests for asserting it is not a fuzzy int */
+    public function testAssertIsNotFuzzyInt(): void
+    {
+        $values = ["abc", 1.23, -1.23, true, false, null, [], [1, 2, 3], new \stdClass(), fopen('php://memory', 'r')];
+        $this->assertFailValues($this->fuzzy, $values, "int");
+    }
+
+    /** @testdox has extended tests for asserting it is not a fuzzy bool */
+    public function testAssertIsNotFuzzyBool(): void
+    {
+        $values = [new \stdClass(), fopen('php://memory', 'r')];
+        $this->assertFailValues($this->fuzzy, $values, "bool");
+    }
+
+    /** @testdox has extended tests for asserting it is not a fuzzy array */
+    public function testAssertIsNotFuzzyArray(): void
+    {
+        $values = ["not an array", 123, 1.23, true, false, null, new \stdClass(), fopen('php://memory', 'r')];
+        $this->assertFailValues($this->fuzzy, $values, "array");
+    }
+
+    /** @testdox has extended tests for asserting it is not a fuzzy object */
+    public function testAssertIsNotFuzzyObject(): void
+    {
+        $values = ["not an object", 123, 1.23, null, [], [1, 2, 3], new AnotherDummy(), fopen('php://memory', 'r')];
+        $this->assertFailValues($this->fuzzy, $values, 'TestDummy');
+    }
+
+    /** @testdox has extended tests for asserting it is not a fuzzy specific object */
+    public function testAssertIsNotFuzzySpecificObject(): void
+    {
+        $values = ["not an object", 123, 1.23, null, [], [1, 2, 3], new \stdClass(), fopen('php://memory', 'r')];
+        $this->assertFailValues($this->fuzzy, $values, TestDummy::class);
+    }
+}

--- a/tests/Benchmark/DataTypeValidatorBench.php
+++ b/tests/Benchmark/DataTypeValidatorBench.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of DataTypeValidator, a PHP Experts, Inc., Project.
  *
- * Copyright © 2019 PHP Experts, Inc.
+ * Copyright © 2019-2025 PHP Experts, Inc.
  * Author: Theodore R. Smith <theodore@phpexperts.pro>
  *  GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
  *  https://www.phpexperts.pro/

--- a/tests/DataTypeValidatorTest.php
+++ b/tests/DataTypeValidatorTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of DataTypeValidator, a PHP Experts, Inc., Project.
  *
- * Copyright © 2019 PHP Experts, Inc.
+ * Copyright © 2019-2025 PHP Experts, Inc.
  * Author: Theodore R. Smith <theodore@phpexperts.pro>
  *  GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
  *  https://www.phpexperts.pro/

--- a/tests/DataTypeValidatorTest.php
+++ b/tests/DataTypeValidatorTest.php
@@ -250,7 +250,7 @@ class DataTypeValidatorTest extends TestCase
 
         try {
             $this->fuzzy->validate($nullArray, $rules);
-        } catch (InvalidDataTypeException $e) {
+        } catch (InvalidDataTypeException) {
         }
     }
 

--- a/tests/DataTypesLists.php
+++ b/tests/DataTypesLists.php
@@ -79,6 +79,8 @@ abstract class DataTypesLists
             ['bool',              '1'],
             ['bool',                0],
             ['bool',                1],
+            ['bool',               []],
+            ['bool',            [123]],
             ['bool',             null],
 
             ['int',               '1'],

--- a/tests/DataTypesLists.php
+++ b/tests/DataTypesLists.php
@@ -75,13 +75,10 @@ abstract class DataTypesLists
     public static function getValidFuzzyDataAndTypes(): array
     {
         return array_merge([
-            ['bool',           'true'],
-            ['bool',          'false'],
             ['bool',              '0'],
             ['bool',              '1'],
             ['bool',                0],
             ['bool',                1],
-            ['bool',               []],
             ['bool',             null],
 
             ['int',               '1'],


### PR DESCRIPTION
* **[2025-03-12 17:29:39 CDT]** Made PHP v8.0 the minimum PHP version.
* **[2025-03-12 18:55:13 CDT]** Migrated to PHP 8.0-compatible code.
* **[2025-03-12 18:58:21 CDT]** Upgraded to PHPUnit v9.6.
* **[2025-03-12 19:08:19 CDT]** Refactored the data types detectors for more succinctness.
* **[2025-03-12 19:31:58 CDT]** Added PHP 8.0 method signatures.
* **[2025-03-13 10:11:47 CDT]** [BREAKING] Strings "true" and "false" are no longer considered fuzzy bools.
* **[2025-03-13 10:54:02 CDT]** Added a comprehensive test suite for DataTypeValidator::assertIsAType().
* **[2025-03-13 10:57:54 CDT]** [m] Minor editorial tweaks.