### PR TITLE
Version 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+
+## v1.8.0
+* **[2025-04-10 07:42:15 CDT]** [BREAKING BACKPORT] Explicitly assert that extra values are not permitted in Strict mode.
+* **[2025-04-10 07:40:57 CDT]** [BACKPORT] Added a mechanism for self-identifying whether a validator is strict or not.
+
+## v1.7.0
+* **[2025-03-17 15:21:09 CDT]** [BACKPORT] Added support for mixed types (no validation).
+
+## v1.6.2
+* **[2025-03-13 17:05:30 CDT]** [m] Fixed a PHP 8.0+ deprecation.
+
+## v1.6.1
+* **[2025-03-13 10:31:59 CDT]** Added a comprehensive test suite for DataTypeValidator::assertIsAType().
+* **[2025-03-13 10:25:07 CDT]** Fixed a bug where all strings, arrays, etc. were treated incorrectly as fuzzy bools.
+
+## v1.6.0
+* **[2025-03-12 16:10:51 CDT]** [m] Removed a very tiny piece of dead code. tag: v1.6.0
+* **[2025-03-12 15:45:42 CDT]** [m] Upgraded to modern phpbench.
+* **[2025-03-12 15:43:41 CDT]** Installed phpexperts/dockerize to be able to run the project's tests via PHP v7.1.
+* **[2025-03-12 15:01:33 CDT]** [m] Added some tests for strict 0.0 float.
+* **[2020-07-28 22:39:05 CDT]** about some PHPUnit stuffs peter279k/test_enhancement, test_enhancement
+
+## v1.5.2
+* **[2019-07-30 13:13:11 CDT]** Allow nullable and empty arrays of something. hopeseekr/better_nullable_arrays
+
+## v1.5.1
+* **[2019-07-28 14:10:07 CDT]** Now filters out the "[]" when checking for arrays of something. hopeseekr/better_arrays
+
+## v1.5.0
+* **[2019-05-27 12:30:05 CDT]** Added a .gitattributes.
+* **[2019-05-27 12:26:14 CDT]** Added support for validating arrays of something.
+* **[2019-05-27 10:33:51 CDT]** Largely refactored how specific objects are validated.
+
+
+## v1.0.3
+* **[2019-05-20 11:44:39 CDT]** Added the ability to retrieve what data type validation logic is used. tag: v1.0.3
+
+## v1.0.2
+* **[2019-05-19 21:31:38 CDT]** Removed dead code.
+* **[2019-05-19 21:28:52 CDT]** Fixed a bug with filter_var().
+
+## v1.0.1
+* **[2019-05-17 07:58:28 CDT]** Added support for nullable data types. hopeseekr/better_nullables
+ 
+## v1.0.0
+* **[2019-05-12 13:55:16 CDT]** [m] Tweak the packagist search terms.
+* **[2019-05-12 13:43:29 CDT]** Let's see if CodeClimate is so easily confused. hopeseekr/improve_score
+* **[2019-05-12 13:29:38 CDT]** Handle an edge case where a rule is not a string. hopeseekr/null_types
+* **[2019-05-12 13:14:40 CDT]** Fixed PHP 7.1 support.
+* **[2019-05-12 13:08:48 CDT]** Added the license header.
+* **[2019-05-12 13:07:34 CDT]** Some cleanup.
+* **[2019-05-12 13:07:17 CDT]** Added the ability to specify any data type as nullable with a "?".
+* **[2019-05-12 12:38:02 CDT]** Added TravisCI support.
+* **[2019-05-12 12:35:42 CDT]** Integrated CodeClimate.
+* **[2019-05-12 12:28:09 CDT]** Version 1.0.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Via Composer
 composer require phpexperts/datatype-validator
 ```
 
+## Upgrading to v3:
+
+As of v3.0, extra values not in the ruleset are explicitly asserted against when operating
+in strict mode. To upgrade, either use the `$this->isStrictMode()` to ensure you don't have
+extra inputs, or use the Fuzzy validator.
+
 ## Usage
 
 ```php
@@ -105,10 +111,12 @@ PHP v8.4 with opcache enabled
 # Use cases
 
 PHPExperts\DataTypeValidator\DataTypeValidator  
+ ✔ Will report whether a strict or permissive validator is being used  
  ✔ Can bulk validate a data array  
  ✔ Will return the name of the data validator logic  
  ✔ Will return an array of invalid keys with explanations  
- ✔ Will silently ignore data not in the rules  
+ ✔ Will silently ignore data not in the rules in permissive mode  
+ ✔ Will explicitly fail when data is not in the rules in strict mode  
  ✔ Will silently ignore nullable rules with no data  
  ✔ Data cannot be null by default  
  ✔ Any data type that starts with a '?' is nullable  
@@ -147,9 +155,10 @@ PHPExperts\DataTypeValidator\DataTypeValidator: Data Type Checks
  ✔ Can validate strings loosely  
  ✔ Can validate arrays loosely  
  ✔ Will validate arrays of something  
-✔ Will validate anything as mixed type  
+ ✔ Will validate anything as mixed type  
 
 PHPExperts\DataTypeValidator\IsAFuzzyDataType  
+ ✔ Will say that it is a permissive validator  
  ✔ Will return true for valid values  
  ✔ Will return false for invalid values  
  ✔ Will match short classes  
@@ -157,6 +166,7 @@ PHPExperts\DataTypeValidator\IsAFuzzyDataType
  ✔ Will work with an array of something  
 
 PHPExperts\DataTypeValidator\IsAStrictDataType  
+ ✔ Will say that it is a strict validator  
  ✔ Will return true for valid values  
  ✔ Will return false for invalid values  
  ✔ Will match short classes  

--- a/src/DataTypeValidator.php
+++ b/src/DataTypeValidator.php
@@ -26,6 +26,11 @@ final class DataTypeValidator implements IsA
         $this->isA = $isA;
     }
 
+    public function isStrictValidator(): bool
+    {
+        return $this->isA->isStrictValidator();
+    }
+
     public function getValidationType(): string
     {
         return get_class($this->isA);
@@ -194,6 +199,7 @@ final class DataTypeValidator implements IsA
     public function validate(array $values, array $rules): bool
     {
         $reasons = [];
+
         foreach ($rules as $key => $expectedType) {
             if (!$this->isString($expectedType)) {
                 throw new LogicException("The data type for $key is not a string.");

--- a/src/DataTypeValidator.php
+++ b/src/DataTypeValidator.php
@@ -200,6 +200,15 @@ final class DataTypeValidator implements IsA
     {
         $reasons = [];
 
+        // Check for extra properties not defined in rules.
+        if ($this->isStrictValidator() === true) {
+            foreach ($values as $key => $value) {
+                if (!isset($rules[$key])) {
+                    $reasons[$key] = "'$key' is not a configured DTO property";
+                }
+            }
+        }
+
         foreach ($rules as $key => $expectedType) {
             if (!$this->isString($expectedType)) {
                 throw new LogicException("The data type for $key is not a string.");

--- a/src/IsA.php
+++ b/src/IsA.php
@@ -18,6 +18,7 @@ interface IsA
 {
     public const KNOWN_TYPES = ['string', 'int', 'array', 'bool', 'float', 'double', 'object', 'callable', 'resource'];
 
+    public function isStrictValidator(): bool;
     public function isMixed($value): bool;
     public function isBool($value): bool;
     public function isInt($value): bool;

--- a/src/IsADataType.php
+++ b/src/IsADataType.php
@@ -16,7 +16,9 @@ namespace PHPExperts\DataTypeValidator;
 
 abstract class IsADataType implements IsA
 {
-    public function isType($value, $dataType): bool
+    abstract public function isStrictValidator(): bool;
+
+    public function isType($value, string $dataType): bool
     {
         $isA = "is{$dataType}";
 

--- a/src/IsAFuzzyDataType.php
+++ b/src/IsAFuzzyDataType.php
@@ -16,6 +16,11 @@ namespace PHPExperts\DataTypeValidator;
 
 class IsAFuzzyDataType extends IsAStrictDataType
 {
+    public function isStrictValidator(): bool
+    {
+        return false;
+    }
+
     public function isBool($value): bool
     {
         $isSpecialType = in_array(gettype($value), ['object', 'resource', 'unknown type']);

--- a/src/IsAStrictDataType.php
+++ b/src/IsAStrictDataType.php
@@ -18,6 +18,11 @@ use ReflectionClass;
 
 class IsAStrictDataType extends IsADataType
 {
+    public function isStrictValidator(): bool
+    {
+        return true;
+    }
+
     public function isBool($value): bool
     {
         return is_bool($value);

--- a/tests/DataTypeValidatorTest.php
+++ b/tests/DataTypeValidatorTest.php
@@ -108,7 +108,7 @@ class DataTypeValidatorTest extends TestCase
         }
     }
 
-    public function testWillSilentlyIgnoreDataNotInTheRules()
+    public function testWillSilentlyIgnoreDataNotInTheRulesInPermissiveMode()
     {
         $data = [
             'name'     => 'Cheyenne',
@@ -119,7 +119,26 @@ class DataTypeValidatorTest extends TestCase
             'name'     => 'string',
         ];
 
-        self::assertTrue($this->strict->validate($data, $rules), 'Invalid data validated :o');
+        self::assertTrue($this->fuzzy->validate($data, $rules), 'Invalid data validated :o');
+    }
+
+    public function testWillExplicitlyFailWhenDataIsNotInTheRulesInStrictMode()
+    {
+        $data = [
+            'name'     => 'Cheyenne',
+            'favFood'  => 'Italian',
+        ];
+
+        $rules = [
+            'name'     => 'string',
+        ];
+
+        try {
+            $this->strict->validate($data, $rules);
+            self::fail('Worked with an extra property in Strict Mode');
+        } catch (InvalidDataTypeException $e) {
+            self::assertEquals(['favFood' => "'favFood' is not a configured DTO property"], $e->getReasons());
+        }
     }
 
     public function testWillSilentlyIgnoreNullableRulesWithNoData()

--- a/tests/DataTypeValidatorTest.php
+++ b/tests/DataTypeValidatorTest.php
@@ -38,6 +38,12 @@ class DataTypeValidatorTest extends TestCase
         parent::setUp();
     }
 
+    public function testWillReportWhetherAStrictOrPermissiveValidatorIsBeingUsed()
+    {
+        self::assertTrue($this->strict->isStrictValidator());
+        self::assertFalse($this->fuzzy->isStrictValidator());
+    }
+
     public function testCanBulkValidateADataArray()
     {
         $data = [

--- a/tests/IsAFuzzyDataTypeTest.php
+++ b/tests/IsAFuzzyDataTypeTest.php
@@ -30,6 +30,11 @@ class IsAFuzzyDataTypeTest extends TestCase
         parent::setUp();
     }
 
+    public function testWillSayThatItIsAPermissiveValidator()
+    {
+        self::assertFalse($this->isA->isStrictValidator());
+    }
+
     public function testWillReturnTrueForValidValues()
     {
         $strictTypePairs = DataTypesLists::getValidStrictDataAndTypes();

--- a/tests/IsAStrictDataTypeTest.php
+++ b/tests/IsAStrictDataTypeTest.php
@@ -30,6 +30,11 @@ class IsAStrictDataTypeTest extends TestCase
         parent::setUp();
     }
 
+    public function testWillSayThatItIsAStrictValidator()
+    {
+        self::assertTrue($this->isA->isStrictValidator());
+    }
+
     public function testWillReturnTrueForValidValues()
     {
         $strictTypePairs = DataTypesLists::getValidStrictDataAndTypes();


### PR DESCRIPTION
* **[2025-04-10 07:42:15 CDT]** [BREAKING BACKPORT] Explicitly assert that extra values are not permitted in Strict mode.
* **[2025-04-10 07:40:57 CDT]** [BACKPORT] Added a mechanism for self-identifying whether a validator is strict or not.
    
**Warning:** This is an API-breaking change !! But it is necessary to violate semver to backport to PHP v7.4 support...
